### PR TITLE
Fix `TypeError` with Python 2.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+from io
 from os import path
 from glob import glob
 from string import capwords
@@ -5,7 +6,7 @@ from setuptools import setup
 
 base_dir = path.abspath(path.dirname(__file__))
 
-with open(path.join(base_dir, 'README.rst'), encoding='utf-8') as f:
+with io.open(path.join(base_dir, 'README.rst'), encoding='utf-8') as f:
     long_description = f.read()
 
 styles = []


### PR DESCRIPTION
Here's the error I was seeing:
```bash
$ python -V
Python 2.7.13
$ python setup.py install
Traceback (most recent call last):
  File "setup.py", line 8, in <module>
    with open(path.join(base_dir, 'README.rst'), encoding='utf-8') as f:
TypeError: 'encoding' is an invalid keyword argument for this function
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mohd-akram/base16-pygments/1)
<!-- Reviewable:end -->
