### PR TITLE
Add some extra token types

### DIFF
--- a/pygments_base16/base16-3024.py
+++ b/pygments_base16/base16-3024.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-apathy.py
+++ b/pygments_base16/base16-apathy.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-apprentice.py
+++ b/pygments_base16/base16-apprentice.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-ashes.py
+++ b/pygments_base16/base16-ashes.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-atelier-cave-light.py
+++ b/pygments_base16/base16-atelier-cave-light.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-atelier-cave.py
+++ b/pygments_base16/base16-atelier-cave.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-atelier-dune-light.py
+++ b/pygments_base16/base16-atelier-dune-light.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-atelier-dune.py
+++ b/pygments_base16/base16-atelier-dune.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-atelier-estuary-light.py
+++ b/pygments_base16/base16-atelier-estuary-light.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-atelier-estuary.py
+++ b/pygments_base16/base16-atelier-estuary.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-atelier-forest-light.py
+++ b/pygments_base16/base16-atelier-forest-light.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-atelier-forest.py
+++ b/pygments_base16/base16-atelier-forest.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-atelier-heath-light.py
+++ b/pygments_base16/base16-atelier-heath-light.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-atelier-heath.py
+++ b/pygments_base16/base16-atelier-heath.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-atelier-lakeside-light.py
+++ b/pygments_base16/base16-atelier-lakeside-light.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-atelier-lakeside.py
+++ b/pygments_base16/base16-atelier-lakeside.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-atelier-plateau-light.py
+++ b/pygments_base16/base16-atelier-plateau-light.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-atelier-plateau.py
+++ b/pygments_base16/base16-atelier-plateau.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-atelier-savanna-light.py
+++ b/pygments_base16/base16-atelier-savanna-light.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-atelier-savanna.py
+++ b/pygments_base16/base16-atelier-savanna.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-atelier-seaside-light.py
+++ b/pygments_base16/base16-atelier-seaside-light.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-atelier-seaside.py
+++ b/pygments_base16/base16-atelier-seaside.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-atelier-sulphurpool-light.py
+++ b/pygments_base16/base16-atelier-sulphurpool-light.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-atelier-sulphurpool.py
+++ b/pygments_base16/base16-atelier-sulphurpool.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-atlas.py
+++ b/pygments_base16/base16-atlas.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-bespin.py
+++ b/pygments_base16/base16-bespin.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-black-metal-bathory.py
+++ b/pygments_base16/base16-black-metal-bathory.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-black-metal-burzum.py
+++ b/pygments_base16/base16-black-metal-burzum.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-black-metal-dark-funeral.py
+++ b/pygments_base16/base16-black-metal-dark-funeral.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-black-metal-gorgoroth.py
+++ b/pygments_base16/base16-black-metal-gorgoroth.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-black-metal-immortal.py
+++ b/pygments_base16/base16-black-metal-immortal.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-black-metal-khold.py
+++ b/pygments_base16/base16-black-metal-khold.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-black-metal-marduk.py
+++ b/pygments_base16/base16-black-metal-marduk.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-black-metal-mayhem.py
+++ b/pygments_base16/base16-black-metal-mayhem.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-black-metal-nile.py
+++ b/pygments_base16/base16-black-metal-nile.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-black-metal-venom.py
+++ b/pygments_base16/base16-black-metal-venom.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-black-metal.py
+++ b/pygments_base16/base16-black-metal.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-brewer.py
+++ b/pygments_base16/base16-brewer.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-bright.py
+++ b/pygments_base16/base16-bright.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-brogrammer.py
+++ b/pygments_base16/base16-brogrammer.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-brushtrees-dark.py
+++ b/pygments_base16/base16-brushtrees-dark.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-brushtrees.py
+++ b/pygments_base16/base16-brushtrees.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-chalk.py
+++ b/pygments_base16/base16-chalk.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-circus.py
+++ b/pygments_base16/base16-circus.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-classic-dark.py
+++ b/pygments_base16/base16-classic-dark.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-classic-light.py
+++ b/pygments_base16/base16-classic-light.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-codeschool.py
+++ b/pygments_base16/base16-codeschool.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-colors.py
+++ b/pygments_base16/base16-colors.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-cupcake.py
+++ b/pygments_base16/base16-cupcake.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-cupertino.py
+++ b/pygments_base16/base16-cupertino.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-danqing-light.py
+++ b/pygments_base16/base16-danqing-light.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-danqing.py
+++ b/pygments_base16/base16-danqing.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-darcula.py
+++ b/pygments_base16/base16-darcula.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-darkmoss.py
+++ b/pygments_base16/base16-darkmoss.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-darktooth.py
+++ b/pygments_base16/base16-darktooth.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-darkviolet.py
+++ b/pygments_base16/base16-darkviolet.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-decaf.py
+++ b/pygments_base16/base16-decaf.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-default-dark.py
+++ b/pygments_base16/base16-default-dark.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-default-light.py
+++ b/pygments_base16/base16-default-light.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-dirtysea.py
+++ b/pygments_base16/base16-dirtysea.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-dracula.py
+++ b/pygments_base16/base16-dracula.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-edge-dark.py
+++ b/pygments_base16/base16-edge-dark.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-edge-light.py
+++ b/pygments_base16/base16-edge-light.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-eighties.py
+++ b/pygments_base16/base16-eighties.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-embers.py
+++ b/pygments_base16/base16-embers.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-equilibrium-dark.py
+++ b/pygments_base16/base16-equilibrium-dark.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-equilibrium-gray-dark.py
+++ b/pygments_base16/base16-equilibrium-gray-dark.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-equilibrium-gray-light.py
+++ b/pygments_base16/base16-equilibrium-gray-light.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-equilibrium-light.py
+++ b/pygments_base16/base16-equilibrium-light.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-espresso.py
+++ b/pygments_base16/base16-espresso.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-eva-dim.py
+++ b/pygments_base16/base16-eva-dim.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-eva.py
+++ b/pygments_base16/base16-eva.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-flat.py
+++ b/pygments_base16/base16-flat.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-framer.py
+++ b/pygments_base16/base16-framer.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-fruit-soda.py
+++ b/pygments_base16/base16-fruit-soda.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-gigavolt.py
+++ b/pygments_base16/base16-gigavolt.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-github.py
+++ b/pygments_base16/base16-github.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-google-dark.py
+++ b/pygments_base16/base16-google-dark.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-google-light.py
+++ b/pygments_base16/base16-google-light.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-grayscale-dark.py
+++ b/pygments_base16/base16-grayscale-dark.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-grayscale-light.py
+++ b/pygments_base16/base16-grayscale-light.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-greenscreen.py
+++ b/pygments_base16/base16-greenscreen.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-gruber.py
+++ b/pygments_base16/base16-gruber.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-gruvbox-dark-hard.py
+++ b/pygments_base16/base16-gruvbox-dark-hard.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-gruvbox-dark-medium.py
+++ b/pygments_base16/base16-gruvbox-dark-medium.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-gruvbox-dark-pale.py
+++ b/pygments_base16/base16-gruvbox-dark-pale.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-gruvbox-dark-soft.py
+++ b/pygments_base16/base16-gruvbox-dark-soft.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-gruvbox-light-hard.py
+++ b/pygments_base16/base16-gruvbox-light-hard.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-gruvbox-light-medium.py
+++ b/pygments_base16/base16-gruvbox-light-medium.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-gruvbox-light-soft.py
+++ b/pygments_base16/base16-gruvbox-light-soft.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-hardcore.py
+++ b/pygments_base16/base16-hardcore.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-harmonic-dark.py
+++ b/pygments_base16/base16-harmonic-dark.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-harmonic-light.py
+++ b/pygments_base16/base16-harmonic-light.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-heetch-light.py
+++ b/pygments_base16/base16-heetch-light.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-heetch.py
+++ b/pygments_base16/base16-heetch.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-helios.py
+++ b/pygments_base16/base16-helios.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-hopscotch.py
+++ b/pygments_base16/base16-hopscotch.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-horizon-dark.py
+++ b/pygments_base16/base16-horizon-dark.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-horizon-light.py
+++ b/pygments_base16/base16-horizon-light.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-horizon-terminal-dark.py
+++ b/pygments_base16/base16-horizon-terminal-dark.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-horizon-terminal-light.py
+++ b/pygments_base16/base16-horizon-terminal-light.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-humanoid-dark.py
+++ b/pygments_base16/base16-humanoid-dark.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-humanoid-light.py
+++ b/pygments_base16/base16-humanoid-light.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-icy.py
+++ b/pygments_base16/base16-icy.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-irblack.py
+++ b/pygments_base16/base16-irblack.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-isotope.py
+++ b/pygments_base16/base16-isotope.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-kimber.py
+++ b/pygments_base16/base16-kimber.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-macintosh.py
+++ b/pygments_base16/base16-macintosh.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-marrakesh.py
+++ b/pygments_base16/base16-marrakesh.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-materia.py
+++ b/pygments_base16/base16-materia.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-material-darker.py
+++ b/pygments_base16/base16-material-darker.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-material-lighter.py
+++ b/pygments_base16/base16-material-lighter.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-material-palenight.py
+++ b/pygments_base16/base16-material-palenight.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-material-vivid.py
+++ b/pygments_base16/base16-material-vivid.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-material.py
+++ b/pygments_base16/base16-material.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-mellow-purple.py
+++ b/pygments_base16/base16-mellow-purple.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-mexico-light.py
+++ b/pygments_base16/base16-mexico-light.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-mocha.py
+++ b/pygments_base16/base16-mocha.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-monokai.py
+++ b/pygments_base16/base16-monokai.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-nebula.py
+++ b/pygments_base16/base16-nebula.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-nord.py
+++ b/pygments_base16/base16-nord.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-nova.py
+++ b/pygments_base16/base16-nova.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-ocean.py
+++ b/pygments_base16/base16-ocean.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-oceanicnext.py
+++ b/pygments_base16/base16-oceanicnext.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-one-light.py
+++ b/pygments_base16/base16-one-light.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-onedark.py
+++ b/pygments_base16/base16-onedark.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-outrun-dark.py
+++ b/pygments_base16/base16-outrun-dark.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-papercolor-dark.py
+++ b/pygments_base16/base16-papercolor-dark.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-papercolor-light.py
+++ b/pygments_base16/base16-papercolor-light.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-paraiso.py
+++ b/pygments_base16/base16-paraiso.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-pasque.py
+++ b/pygments_base16/base16-pasque.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-phd.py
+++ b/pygments_base16/base16-phd.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-pico.py
+++ b/pygments_base16/base16-pico.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-pinky.py
+++ b/pygments_base16/base16-pinky.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-pop.py
+++ b/pygments_base16/base16-pop.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-porple.py
+++ b/pygments_base16/base16-porple.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-qualia.py
+++ b/pygments_base16/base16-qualia.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-railscasts.py
+++ b/pygments_base16/base16-railscasts.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-rebecca.py
+++ b/pygments_base16/base16-rebecca.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-rose-pine-dawn.py
+++ b/pygments_base16/base16-rose-pine-dawn.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-rose-pine-moon.py
+++ b/pygments_base16/base16-rose-pine-moon.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-rose-pine.py
+++ b/pygments_base16/base16-rose-pine.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-sagelight.py
+++ b/pygments_base16/base16-sagelight.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-sakura.py
+++ b/pygments_base16/base16-sakura.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-sandcastle.py
+++ b/pygments_base16/base16-sandcastle.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-seti.py
+++ b/pygments_base16/base16-seti.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-shades-of-purple.py
+++ b/pygments_base16/base16-shades-of-purple.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-shapeshifter.py
+++ b/pygments_base16/base16-shapeshifter.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-silk-dark.py
+++ b/pygments_base16/base16-silk-dark.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-silk-light.py
+++ b/pygments_base16/base16-silk-light.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-snazzy.py
+++ b/pygments_base16/base16-snazzy.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-solarflare-light.py
+++ b/pygments_base16/base16-solarflare-light.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-solarflare.py
+++ b/pygments_base16/base16-solarflare.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-solarized-dark.py
+++ b/pygments_base16/base16-solarized-dark.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-solarized-light.py
+++ b/pygments_base16/base16-solarized-light.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-spacemacs.py
+++ b/pygments_base16/base16-spacemacs.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-summercamp.py
+++ b/pygments_base16/base16-summercamp.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-summerfruit-dark.py
+++ b/pygments_base16/base16-summerfruit-dark.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-summerfruit-light.py
+++ b/pygments_base16/base16-summerfruit-light.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-synth-midnight-dark.py
+++ b/pygments_base16/base16-synth-midnight-dark.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-synth-midnight-light.py
+++ b/pygments_base16/base16-synth-midnight-light.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-tango.py
+++ b/pygments_base16/base16-tango.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-tender.py
+++ b/pygments_base16/base16-tender.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-tomorrow-night.py
+++ b/pygments_base16/base16-tomorrow-night.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-tomorrow.py
+++ b/pygments_base16/base16-tomorrow.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-tube.py
+++ b/pygments_base16/base16-tube.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-twilight.py
+++ b/pygments_base16/base16-twilight.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-unikitty-dark.py
+++ b/pygments_base16/base16-unikitty-dark.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-unikitty-light.py
+++ b/pygments_base16/base16-unikitty-light.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-vice-alt.py
+++ b/pygments_base16/base16-vice-alt.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-vice.py
+++ b/pygments_base16/base16-vice.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-vulcan.py
+++ b/pygments_base16/base16-vulcan.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-windows-10-light.py
+++ b/pygments_base16/base16-windows-10-light.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-windows-10.py
+++ b/pygments_base16/base16-windows-10.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-windows-95-light.py
+++ b/pygments_base16/base16-windows-95-light.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-windows-95.py
+++ b/pygments_base16/base16-windows-95.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-windows-highcontrast-light.py
+++ b/pygments_base16/base16-windows-highcontrast-light.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-windows-highcontrast.py
+++ b/pygments_base16/base16-windows-highcontrast.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-windows-nt-light.py
+++ b/pygments_base16/base16-windows-nt-light.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-windows-nt.py
+++ b/pygments_base16/base16-windows-nt.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-woodland.py
+++ b/pygments_base16/base16-woodland.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-xcode-dusk.py
+++ b/pygments_base16/base16-xcode-dusk.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/pygments_base16/base16-zenburn.py
+++ b/pygments_base16/base16-zenburn.py
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si

--- a/templates/default.mustache
+++ b/templates/default.mustache
@@ -1,6 +1,6 @@
 from pygments.style import Style
 from pygments.token import (
-    Comment, Error, Keyword, Literal, Name, Number, Operator, String, Text
+    Comment, Error, Keyword, Literal, Name, Number, Operator, Punctuation, String, Text
 )
 
 
@@ -38,6 +38,7 @@ class Base16Style(Style):
         Keyword: base0e,  # .k
         Keyword.Type: base08,  # .kt
 
+        Name: base0d,  # .n
         Name.Attribute: base0d,  # .na
         Name.Builtin: base0d,  # .nb
         Name.Builtin.Pseudo: base08,  # .bp
@@ -56,6 +57,7 @@ class Base16Style(Style):
         Operator.Word: base0e,  # .ow
 
         Literal: base0b,  # .l
+        Punctuation: base0c,  # .p
 
         String: base0b,  # .s
         String.Interpol: base0f,  # .si


### PR DESCRIPTION
Add the following tokens:

- `Token.Name`
- `Token.Punctuation`

Fixes behaviour in `rich.syntax.PygmentsSyntaxTheme`, which defaults unknown tokens to black.